### PR TITLE
update proto.vim

### DIFF
--- a/syntax/proto.vim
+++ b/syntax/proto.vim
@@ -1,6 +1,6 @@
 " Protocol Buffers - Google's data interchange format
 " Copyright 2008 Google Inc.  All rights reserved.
-" http://code.google.com/p/protobuf/
+" https://developers.google.com/protocol-buffers/
 "
 " Redistribution and use in source and binary forms, with or without
 " modification, are permitted provided that the following conditions are
@@ -54,7 +54,7 @@ syn keyword pbTodo       contained TODO FIXME XXX
 syn cluster pbCommentGrp contains=pbTodo
 
 syn keyword pbSyntax     syntax import option
-syn keyword pbStructure  package message group
+syn keyword pbStructure  package message group oneof
 syn keyword pbRepeat     optional required repeated
 syn keyword pbDefault    default
 syn keyword pbExtend     extend extensions to max
@@ -69,11 +69,10 @@ syn keyword pbBool      true false
 syn match   pbInt     /-\?\<\d\+\>/
 syn match   pbInt     /\<0[xX]\x+\>/
 syn match   pbFloat   /\<-\?\d*\(\.\d*\)\?/
-" TODO: .proto also supports C-style block comments;
-" see /usr/share/vim/vim70/syntax/c.vim for how it's done.
+syn region  pbComment start="\/\*" end="\*\/" contains=@pbCommentGrp
 syn region  pbComment start="//" skip="\\$" end="$" keepend contains=@pbCommentGrp
-syn region  pbString  start=/"/ skip=/\\"/ end=/"/
-syn region  pbString  start=/'/ skip=/\\'/ end=/'/
+syn region  pbString  start=/"/ skip=/\\./ end=/"/
+syn region  pbString  start=/'/ skip=/\\./ end=/'/
 
 if version >= 508 || !exists("did_proto_syn_inits")
   if version < 508


### PR DESCRIPTION
Updated proto.vim to this version (26 Nov 2014):  
https://github.com/google/protobuf/blob/33bb176603b749fb957410f2bd82a27b08898e22/editors/proto.vim
